### PR TITLE
expose input_shape and add config tests

### DIFF
--- a/run_training.py
+++ b/run_training.py
@@ -1,4 +1,5 @@
 import argparse
+import ast
 from pathlib import Path
 
 from cellxpredict.config import Models, config_from_args
@@ -46,6 +47,13 @@ if __name__ == "__main__":
     )
 
     parser.add_argument(
+        "--input_shape",
+        type=ast.literal_eval,
+        default=(64, 64, 2),
+        help="input shape of the image data (W, H, C)",
+    )
+
+    parser.add_argument(
         "--batch_size",
         type=int,
         default=256,
@@ -87,6 +95,5 @@ if __name__ == "__main__":
     )
 
     args = parser.parse_args()
-    print(args)
     config = config_from_args(args)
     train(config)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,39 @@
+import argparse
+import ast
+
+import pytest
+
+from cellxpredict import config
+
+MODELS = [m.name.lower() for m in config.Models]
+
+
+@pytest.mark.parametrize("model", MODELS)
+@pytest.mark.parametrize("input_shape", [(8, 8, 1), (64, 64, 2), (128, 128, 8)])
+def test_arg_parse_to_config(model, input_shape):
+    """Test the cmdline arguments to model config."""
+    parser = argparse.ArgumentParser(description="test")
+
+    parser.add_argument(
+        "--model",
+        choices=MODELS,
+        type=str,
+        required=True,
+        help="name of the model to train",
+    )
+
+    parser.add_argument(
+        "--input_shape",
+        type=ast.literal_eval,
+        default=(64, 64, 2),
+        help="input shape of the image data (W, H, C)",
+    )
+
+    args = parser.parse_args(["--model", model, "--input_shape", str(input_shape)])
+    cfg = config.config_from_args(args)
+
+    assert isinstance(cfg, config.ConfigBase)
+    assert args.model == model
+    assert cfg.model == model
+    assert args.input_shape == input_shape
+    assert cfg.input_shape == input_shape


### PR DESCRIPTION
+ [x] expose `input_shape` as a command line argument
+ [x] add tests to check that arguments are correctly passed to models
+ [ ] add verification that input_shape is reasonable

Closes #9, #27 