### PR TITLE
Ease the training grid search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 # Locally saved models / logs / docs
 logs
-docs
 models
 
 # Byte-compiled / optimized / DLL files

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+# Locally saved models / logs / docs
+logs
+docs
+models
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ python run_training.py \
   --model=encoder \
   --src_dir=/path/to/training/patches \
   --log_dir=/path/to/log_dir \
+  --input_shape='(64, 64, 2)'
   --epochs=50 \
 ```
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ python run_training.py \
   --model=encoder \
   --src_dir=/path/to/training/patches \
   --log_dir=/path/to/log_dir \
-  --input_shape='(64, 64, 2)'
+  --input_shape='(64, 64, 2)' \
   --epochs=50 \
 ```
 

--- a/cellxpredict/config.py
+++ b/cellxpredict/config.py
@@ -36,6 +36,7 @@ class EncoderConfig(ConfigBase):
     epochs: int = 50
     batch_size: int = 256
     num_images: int = None
+    steps_per_epoch: int = None
     max_iterations: int = None
     max_iterations_fraction: float = 0.9
 

--- a/cellxpredict/config.py
+++ b/cellxpredict/config.py
@@ -43,7 +43,9 @@ class EncoderConfig(ConfigBase):
     model: str = "encoder"
     epochs: int = 50
     batch_size: int = 256
-    max_iterations: int = 100
+    num_images: int = None
+    max_iterations: int = None
+    max_iterations_fraction: float = None
 
 
 @dataclass

--- a/cellxpredict/config.py
+++ b/cellxpredict/config.py
@@ -17,7 +17,6 @@ class ConfigBase:
     model: str = ""
     src_dir: Optional[os.PathLike] = None
     log_dir: Optional[os.PathLike] = None
-    docs_dir: Optional[os.PathLike] = None
     model_dir: Optional[os.PathLike] = None
     latent_dims: int = 32
     intermediate_dims: int = 256

--- a/cellxpredict/config.py
+++ b/cellxpredict/config.py
@@ -24,7 +24,6 @@ class ConfigBase:
     capacity: int = 50
     gamma: int = 1_000
     input_shape: Tuple[int, int, int] = (64, 64, 2)
-    #input_shape: Tuple[int, int, int] = (128, 128, 1)
     layers: List[int] = field(default_factory=lambda: [8, 16, 32, 64])
 
     def filename(self, component: str = "weights"):
@@ -44,7 +43,6 @@ class EncoderConfig(ConfigBase):
     model: str = "encoder"
     epochs: int = 50
     batch_size: int = 256
-    #max_iterations: int = 200_000
     max_iterations: int = 100
 
 

--- a/cellxpredict/config.py
+++ b/cellxpredict/config.py
@@ -26,13 +26,6 @@ class ConfigBase:
     layers: List[int] = field(default_factory=lambda: [8, 16, 32, 64])
 
     def filename(self, component: str = "weights"):
-        filename = (
-            f"{self.model}_{component}_capacity={self.capacity}_"
-            f"z={self.latent_dims}_gamma={self.gamma}"
-        )
-        return filename
-
-    def filename_brief(self, component: str = "weights"):
         filename = (f"{self.model}_{component}")
         return filename
 
@@ -44,7 +37,7 @@ class EncoderConfig(ConfigBase):
     batch_size: int = 256
     num_images: int = None
     max_iterations: int = None
-    max_iterations_fraction: float = None
+    max_iterations_fraction: float = 0.9
 
 
 @dataclass

--- a/cellxpredict/config.py
+++ b/cellxpredict/config.py
@@ -16,13 +16,15 @@ class Models(enum.Enum):
 class ConfigBase:
     model: str = ""
     src_dir: Optional[os.PathLike] = None
-    model_dir: Optional[os.PathLike] = None
     log_dir: Optional[os.PathLike] = None
+    docs_dir: Optional[os.PathLike] = None
+    model_dir: Optional[os.PathLike] = None
     latent_dims: int = 32
     intermediate_dims: int = 256
     capacity: int = 50
     gamma: int = 1_000
     input_shape: Tuple[int, int, int] = (64, 64, 2)
+    #input_shape: Tuple[int, int, int] = (128, 128, 1)
     layers: List[int] = field(default_factory=lambda: [8, 16, 32, 64])
 
     def filename(self, component: str = "weights"):
@@ -32,13 +34,18 @@ class ConfigBase:
         )
         return filename
 
+    def filename_brief(self, component: str = "weights"):
+        filename = (f"{self.model}_{component}")
+        return filename
+
 
 @dataclass
 class EncoderConfig(ConfigBase):
     model: str = "encoder"
     epochs: int = 50
     batch_size: int = 256
-    max_iterations: int = 200_000
+    #max_iterations: int = 200_000
+    max_iterations: int = 100
 
 
 @dataclass

--- a/cellxpredict/session.py
+++ b/cellxpredict/session.py
@@ -3,7 +3,7 @@ import json
 from pathlib import Path
 from typing import Union
 
-from .config import ConfigBase, EncoderConfig
+from .config import ConfigBase
 
 
 def write_config_json_file(config: ConfigBase) -> None:
@@ -12,12 +12,34 @@ def write_config_json_file(config: ConfigBase) -> None:
     json_data = {prm : str(getattr(config, prm)) for prm in config.__dict__}
 
     # write the data into json file:
-    with open(config.model_dir / 'ConfigHyperParams.json', 'w') as json_file:
+    # model = str(config.model).capitalize()
+    # json_fn = config.model_dir / f'ConfigHyperParams-{model}.json'
+    json_fn = config.model_dir / f'ConfigHyperParams.json'
+    with open(json_fn, 'w') as json_file:
         json.dump(json_data, json_file, indent=4)
 
 
-def load_config_attributes(json_params_file: Union[str, Path]) -> ConfigBase:
-    """Overwrite default config params from JSON file."""
+def load_config_attributes(
+    default_config: ConfigBase,
+    json_params_file: Union[str, Path]
+) -> ConfigBase:
+    """Overwrite default config params from JSON file.
+
+    Parameters
+    ----------
+    default_config : ConfigBase
+        The @dataclass EncoderConfig / TemporalConfig / FullConfig
+        inheriting from ConfigBase.
+
+    json_params_file : Union[str, Path]
+        The path to the JSON file storing the hyperparameters (attributes)
+        of how the model was trained.
+
+    Returns
+    -------
+    default_config : ConfigBase:
+        The respective @dataclass with updated attributes.
+    """
 
     # Check validity of the JSON params file:
     if isinstance(json_params_file, str):
@@ -30,7 +52,7 @@ def load_config_attributes(json_params_file: Union[str, Path]) -> ConfigBase:
         json_data_dict = json.load(json_data)
 
     # Change the attributes to the model's values:
-    default_config = EncoderConfig()  # inherits from ConfigBase()
+    # default_config = EncoderConfig()  # inherits from ConfigBase()
 
     for attr in default_config.__dict__:
 

--- a/cellxpredict/session.py
+++ b/cellxpredict/session.py
@@ -14,7 +14,7 @@ def write_config_json_file(config: ConfigBase) -> None:
     # write the data into json file:
     # model = str(config.model).capitalize()
     # json_fn = config.model_dir / f'ConfigHyperParams-{model}.json'
-    json_fn = config.model_dir / f'ConfigHyperParams.json'
+    json_fn = config.model_dir / 'ConfigHyperParams.json'
     with open(json_fn, 'w') as json_file:
         json.dump(json_data, json_file, indent=4)
 

--- a/cellxpredict/session.py
+++ b/cellxpredict/session.py
@@ -1,0 +1,51 @@
+import json
+
+from pathlib import Path
+from typing import Union
+
+from .config import ConfigBase, EncoderConfig
+
+
+def write_config_json_file(config: ConfigBase) -> None:
+    """Record params of the training run."""
+    # extract the params into dict:
+    json_data = {prm : str(getattr(config, prm)) for prm in config.__dict__}
+
+    # write the data into json file:
+    with open(config.model_dir / 'ConfigHyperParams.json', 'w') as json_file:
+        json.dump(json_data, json_file, indent=4)
+
+
+def load_config_attributes(json_params_file: Union[str, Path]) -> ConfigBase:
+    """Overwrite default config params from JSON file."""
+
+    # Check validity of the JSON params file:
+    if isinstance(json_params_file, str):
+        json_params_file = Path(json_params_file)
+    assert json_params_file.is_file()
+    assert str(json_params_file).endswith('.json')
+
+    # Read the JSON file into dict:
+    with open(json_params_file) as json_data:
+        json_data_dict = json.load(json_data)
+
+    # Change the attributes to the model's values:
+    default_config = EncoderConfig() # inherits from ConfigBase()
+
+    for attr in default_config.__dict__:
+
+        default_value = getattr(default_config, attr)
+        jsonstr_value = json_data_dict[attr]
+
+        if attr.endswith("_dir"):
+            value = Path(jsonstr_value)
+        elif default_value is None:
+            value = int(jsonstr_value)
+        elif isinstance(default_value, (list, tuple)):
+            value = eval(jsonstr_value)
+        else:
+            value = type(default_value)(jsonstr_value)
+
+        setattr(default_config, attr, value)
+
+    return default_config

--- a/cellxpredict/session.py
+++ b/cellxpredict/session.py
@@ -30,7 +30,7 @@ def load_config_attributes(json_params_file: Union[str, Path]) -> ConfigBase:
         json_data_dict = json.load(json_data)
 
     # Change the attributes to the model's values:
-    default_config = EncoderConfig() # inherits from ConfigBase()
+    default_config = EncoderConfig()  # inherits from ConfigBase()
 
     for attr in default_config.__dict__:
 

--- a/cellxpredict/train.py
+++ b/cellxpredict/train.py
@@ -79,17 +79,9 @@ def train_projector(config: ConfigBase):
 
     from .dataset import encoder_validation_dataset
 
-    # set up the model - train if weights don't exist
-    try:
-        model = _build_encoder(config)
-    except (FileNotFoundError, OSError):
-        # train the encoder / decoder from scratch
-        config.model = 'encoder'
-        train_encoder(config)
-        # now load the weights & create the projector
-        config.model = 'projector'
-        model = _build_encoder(config)
-    # print (model.summary())
+    # set up the model
+    model = _build_encoder(config)
+    print (model.summary())
 
     # set up the datasets and augmentation
     projection_dataset = encoder_validation_dataset(config, batch_size=512)
@@ -160,9 +152,11 @@ def train(config: ConfigBase):
 
     # set up a log directory
     config.log_dir = create_tensorboard_log_dir(config.log_dir)
-    config.model_dir = Path(str(config.log_dir).replace("logs", "models"))
+    if config.model == 'encoder':
+        config.model_dir = Path(str(config.log_dir).replace("logs", "models"))
 
     # get the training function
     train_fn = getattr(sys.modules[__name__], f"train_{config.model.lower()}")
     train_fn(config)
-    write_config_json_file(config)
+    if config.model == 'encoder':
+        write_config_json_file(config)

--- a/cellxpredict/train.py
+++ b/cellxpredict/train.py
@@ -82,7 +82,7 @@ def train_projector(config: ConfigBase):
     # set up the model - train if weights don't exist
     try:
         model = _build_encoder(config)
-    except FileNotFoundError:
+    except (FileNotFoundError, OSError):
         # train the encoder / decoder from scratch
         config.model = 'encoder'
         train_encoder(config)

--- a/cellxpredict/train.py
+++ b/cellxpredict/train.py
@@ -81,7 +81,7 @@ def train_projector(config: ConfigBase):
 
     # set up the model
     model = _build_encoder(config)
-    print (model.summary())
+    # print (model.summary())
 
     # set up the datasets and augmentation
     projection_dataset = encoder_validation_dataset(config, batch_size=512)

--- a/cellxpredict/train.py
+++ b/cellxpredict/train.py
@@ -65,10 +65,10 @@ def train_encoder(config: ConfigBase):
 
     # save the model weights
     config.model_dir.mkdir(parents=True, exist_ok=True)
-    model_filename = config.model_dir / config.filename_brief("weights")
+    model_filename = config.model_dir / config.filename("weights")
     model.encoder.save_weights(model_filename.with_suffix(".h5"))
 
-    decoder_filename = config.filename_brief("weights").replace("encoder", "decoder")
+    decoder_filename = config.filename("weights").replace("encoder", "decoder")
     model_filename = config.model_dir / decoder_filename
     model.decoder.save_weights(model_filename.with_suffix(".h5"))
 
@@ -79,8 +79,16 @@ def train_projector(config: ConfigBase):
 
     from .dataset import encoder_validation_dataset
 
-    # set up the model
-    model = _build_encoder(config)
+    # set up the model - train if weights don't exist
+    try:
+        model = _build_encoder(config)
+    except:
+        # train the encoder / decoder from scratch
+        config.model = 'encoder'
+        train_encoder(config)
+        # now load the weights & create the projector
+        config.model = 'projector'
+        model = _build_encoder(config)
     # print (model.summary())
 
     # set up the datasets and augmentation

--- a/cellxpredict/train.py
+++ b/cellxpredict/train.py
@@ -166,6 +166,5 @@ def write_config_dictionary(config: ConfigBase) -> None:
     json_data = {prm : str(getattr(config, prm)) for prm in config.__dict__}
 
     # write the data into json file:
-    file_name = os.path.join(config.model_dir, 'ConfigHyperParams.json')
-    with open(file_name, 'w') as json_file:
+    with open(config.model_dir / 'ConfigHyperParams.json', 'w') as json_file:
         json.dump(json_data, json_file, indent=4)

--- a/cellxpredict/train.py
+++ b/cellxpredict/train.py
@@ -82,7 +82,7 @@ def train_projector(config: ConfigBase):
     # set up the model - train if weights don't exist
     try:
         model = _build_encoder(config)
-    except:
+    except FileNotFoundError:
         # train the encoder / decoder from scratch
         config.model = 'encoder'
         train_encoder(config)

--- a/cellxpredict/train.py
+++ b/cellxpredict/train.py
@@ -1,5 +1,4 @@
 import sys
-import json
 from pathlib import Path
 
 import numpy as np

--- a/cellxpredict/train.py
+++ b/cellxpredict/train.py
@@ -1,6 +1,5 @@
 import sys
 import json
-#import datetime
 from pathlib import Path
 
 import numpy as np
@@ -16,7 +15,6 @@ from .config import ConfigBase
 from .models import _build_autoencoder, _build_encoder, _build_temporal
 
 # TODO(arl): remove these hard-coded values for release
-#NUM_IMAGES = 1_030_766
 NUM_IMAGES = 100
 MONTAGE_SAMPLES = 32
 TEMPORAL_STEPS_PER_EPOCH = 100

--- a/cellxpredict/train.py
+++ b/cellxpredict/train.py
@@ -81,7 +81,7 @@ def train_projector(config: ConfigBase):
 
     # set up the model
     model = _build_encoder(config)
-    model.summary()
+    # print (model.summary())
 
     # set up the datasets and augmentation
     projection_dataset = encoder_validation_dataset(config, batch_size=512)
@@ -162,15 +162,10 @@ def train(config: ConfigBase):
 
 def write_config_dictionary(config: ConfigBase) -> None:
     """Record params of the training run."""
-    # extract the data:
+    # extract the params into dict:
     json_data = {prm : str(getattr(config, prm)) for prm in config.__dict__}
 
-    # write a param json file
-    config.docs_dir = Path(str(config.log_dir).replace("logs", "docs"))
-    config.docs_dir.mkdir(parents=True, exist_ok=True)
-
-    # record the config params
-    time_stamp = str(config.docs_dir).split("/")[-1]
-    file_name = f'{config.docs_dir}/{time_stamp}-Training-Session.json'
+    # write the data into json file:
+    file_name = os.path.join(config.model_dir, 'ConfigHyperParams.json')
     with open(file_name, 'w') as json_file:
         json.dump(json_data, json_file, indent=4)

--- a/run_training.py
+++ b/run_training.py
@@ -61,6 +61,13 @@ if __name__ == "__main__":
     )
 
     parser.add_argument(
+        "--latent_dims",
+        type=int,
+        default=32,
+        help="number of dimensions in latent space embedding",
+    )
+
+    parser.add_argument(
         "--batch_size",
         type=int,
         default=256,

--- a/run_training.py
+++ b/run_training.py
@@ -33,6 +33,13 @@ if __name__ == "__main__":
     )
 
     parser.add_argument(
+        "--docs_dir",
+        type=Path,
+        default=DEFAULT_PATH / "docs",
+        help="path to the documentation output directory",
+    )
+
+    parser.add_argument(
         "--model_dir",
         type=Path,
         default=DEFAULT_PATH / "models",
@@ -68,6 +75,13 @@ if __name__ == "__main__":
     )
 
     parser.add_argument(
+        "--max_iterations",
+        type=int,
+        default=200,
+        help="maximum number of iterations",
+    )
+
+    parser.add_argument(
         "--capacity",
         type=int,
         default=50,
@@ -96,4 +110,5 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
     config = config_from_args(args)
+    print (config)
     train(config)

--- a/run_training.py
+++ b/run_training.py
@@ -66,7 +66,6 @@ if __name__ == "__main__":
         default=32,
         help="number of dimensions in latent space embedding",
     )
-    
     parser.add_argument(
         "--input_dtype",
         type=str,

--- a/run_training.py
+++ b/run_training.py
@@ -33,13 +33,6 @@ if __name__ == "__main__":
     )
 
     parser.add_argument(
-        "--docs_dir",
-        type=Path,
-        default=DEFAULT_PATH / "docs",
-        help="path to the documentation output directory",
-    )
-
-    parser.add_argument(
         "--model_dir",
         type=Path,
         default=DEFAULT_PATH / "models",

--- a/run_training.py
+++ b/run_training.py
@@ -75,10 +75,10 @@ if __name__ == "__main__":
     )
 
     parser.add_argument(
-        "--max_iterations",
-        type=int,
-        default=200,
-        help="maximum number of iterations",
+        "--max_iterations_fraction",
+        type=float,
+        default=0.9,
+        help="percentage of steps before capacity reaches max value",
     )
 
     parser.add_argument(

--- a/run_training.py
+++ b/run_training.py
@@ -54,6 +54,13 @@ if __name__ == "__main__":
     )
 
     parser.add_argument(
+        "--layers",
+        type=ast.literal_eval,
+        default=[8, 16, 32, 64],
+        help="encoder layers list",
+    )
+
+    parser.add_argument(
         "--batch_size",
         type=int,
         default=256,

--- a/run_training.py
+++ b/run_training.py
@@ -110,5 +110,4 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
     config = config_from_args(args)
-    print (config)
     train(config)


### PR DESCRIPTION
- [x] Edit README.md to show that `--input_shape` command line arg tuple needs to be put into quotation marks
- [x] Add command line args in the `run_training.py`: `max_iterations` etc.
- [x] Change how the exported model weights files are named: `config.filename_brief()` fn
- [x] Create parallel subdirectories ( /logs /docs /models ) to records training session with time stamp
- [x] Add .gitignore mentions of the training subdirectories: /logs /docs /models