### PR TITLE
Add `input_dtype` parameter for image data

### DIFF
--- a/cellxpredict/config.py
+++ b/cellxpredict/config.py
@@ -23,6 +23,7 @@ class ConfigBase:
     capacity: int = 50
     gamma: int = 1_000
     input_shape: Tuple[int, int, int] = (64, 64, 2)
+    input_dtype: str = "uint8"
     layers: List[int] = field(default_factory=lambda: [8, 16, 32, 64])
 
     def filename(self, component: str = "weights"):

--- a/cellxpredict/dataset.py
+++ b/cellxpredict/dataset.py
@@ -19,7 +19,11 @@ VALIDATE_FRACTION = 0.1
 
 def encoder_training_dataset(config: ConfigBase):
     """Encoder training dataset."""
-    dataset = build_dataset(config.src_dir, output_shape=config.input_shape)
+    dataset = build_dataset(
+        config.src_dir,
+        output_shape=config.input_shape,
+        output_dtype=config.input_dtype
+    )
     dataset = dataset.shuffle(
         buffer_size=config.batch_size * 1000, reshuffle_each_iteration=True
     )
@@ -39,7 +43,11 @@ def encoder_training_dataset(config: ConfigBase):
 
 def encoder_validation_dataset(config: ConfigBase, batch_size: int = 1):
     """Encoder validation dataset."""
-    dataset = build_dataset(config.src_dir, output_shape=config.input_shape)
+    dataset = build_dataset(
+        config.src_dir,
+        output_shape=config.input_shape,
+        output_dtype=config.input_dtype
+    )
     dataset = dataset.shuffle(
         buffer_size=config.batch_size * 1000, reshuffle_each_iteration=True
     )

--- a/run_training.py
+++ b/run_training.py
@@ -54,6 +54,13 @@ if __name__ == "__main__":
     )
 
     parser.add_argument(
+        "--input_dtype",
+        type=str,
+        default="uint8",
+        help="input dtype of the image data",
+    )
+
+    parser.add_argument(
         "--batch_size",
         type=int,
         default=256,


### PR DESCRIPTION
To reflect changes in `cellx` library that allow for input images of dtype `uint16`